### PR TITLE
Rename app to Copiloto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 <p align="center">
-  <a href="https://pickle.com/glass">
+  <a href="https://laudos.ai">
    <img src="./public/assets/banner.gif" alt="Logo">
   </a>
 
-  <h1 align="center">Glass by Pickle: Digital Mind Extension 🧠</h1>
+  <h1 align="center">Copiloto - por Laudos.ai: Extensão da Mente Digital 🧠</h1>
 
 </p>
 
 
 <p align="center">
-  <a href="https://discord.gg/UCZH5B5Hpd"><img src="./public/assets/button_dc.png" width="80" alt="Pickle Discord"></a>&ensp;<a href="https://pickle.com"><img src="./public/assets/button_we.png" width="105" alt="Pickle Website"></a>&ensp;<a href="https://x.com/intent/user?screen_name=leinadpark"><img src="./public/assets/button_xe.png" width="109" alt="Follow Daniel"></a>
+  <a href="https://discord.gg/UCZH5B5Hpd"><img src="./public/assets/button_dc.png" width="80" alt="Pickle Discord"></a>&ensp;<a href="https://laudos.ai"><img src="./public/assets/button_we.png" width="105" alt="Pickle Website"></a>&ensp;<a href="https://x.com/intent/user?screen_name=leinadpark"><img src="./public/assets/button_xe.png" width="109" alt="Follow Daniel"></a>
 </p>
 
 > This project is a fork of [CheatingDaddy](https://github.com/sohzm/cheating-daddy) with modifications and enhancements. Thanks to [Soham](https://x.com/soham_btw) and all the open-source contributors who made this possible!
 
-🤖 **Fast, light & open-source**—Glass lives on your desktop, sees what you see, listens in real time, understands your context, and turns every moment into structured knowledge.
+🤖 **Rápido, leve e de código aberto**—Copiloto está na sua área de trabalho, vê o que você vê, escuta em tempo real, entende seu contexto e transforma cada momento em conhecimento estruturado.
 
-💬 **Proactive in meetings**—it surfaces action items, summaries, and answers the instant you need them.
+💬 **Proativo em reuniões**—apresenta ações, resumos e respostas no instante em que você precisa.
 
-🫥️ **Truly invisible**—never shows up in screen recordings, screenshots, or your dock; no always-on capture or hidden sharing.
+🫥️ **Realmente invisível**—nunca aparece em gravações de tela, capturas ou no dock; sem captura constante ou compartilhamento oculto.
 
 To have fun building with us, join our [Discord](https://discord.gg/UCZH5B5Hpd)!
 
 ## Instant Launch
 
-⚡️  Skip the setup—launch instantly with our ready-to-run macOS app.  [[Download Here]](https://www.dropbox.com/scl/fi/znid09apxiwtwvxer6oc9/Glass_latest.dmg?rlkey=gwvvyb3bizkl25frhs4k1zwds&st=37q31b4w&dl=1)
+⚡️  Pule a configuração—execute imediatamente com nosso app macOS pronto para uso.  [[Baixar aqui]](https://www.dropbox.com/scl/fi/znid09apxiwtwvxer6oc9/copiloto.dmg?rlkey=gwvvyb3bizkl25frhs4k1zwds&st=37q31b4w&dl=1)
 
 ## Quick Start (Local Build)
 
@@ -68,7 +68,7 @@ npm run setup
 
 You can visit [here](https://platform.openai.com/api-keys) to get your OpenAI API Key.
 
-### Liquid Glass Design (coming soon)
+### Design do Copiloto (em breve)
 
 <img width="100%" alt="booking-screen" src="./public/assets/03.gif">
 
@@ -100,14 +100,14 @@ We love contributions! Feel free to open issues for bugs or feature requests.
 | 🚧 WIP     | Code Refactoring               | Refactoring the entire codebase for better maintainability. |
 | 🚧 WIP      | Firebase Data Storage Issue    | Session & ask should be saved in firebase for signup users |
 | 🚧 WIP      | Login Issue                    | Currently breaking when switching between local and sign-in mode |
-| 🚧 WIP      | Liquid Glass                    | Liquid Glass UI for MacOS 26 |
-| 🚧 WIP      | Permission Issue           | Mic & system audio & display capture permission sometimes not working|
+| 🚧 WIP      | Design Copiloto                    | UI do Copiloto para MacOS 26 |
+| 🚧 WIP      | Design Copiloto                    | UI do Copiloto para MacOS 26 |
 
 
 
 ## About Pickle
 
-**Our mission is to build a living digital clone for everyone.** Glass is part of Step 1—a trusted pipeline that transforms your daily data into a scalable clone. Visit [pickle.com](https://pickle.com) to learn more.
+**Nossa missão é construir um clone digital vivo para todos.** Copiloto é parte do Passo 1—um pipeline confiável que transforma seus dados diários em um clone escalável. Visite [laudos.ai](https://laudos.ai) para saber mais.
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=pickle-com/glass&type=Date)](https://www.star-history.com/#pickle-com/glass&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=laudos-ai/copiloto&type=Date)](https://www.star-history.com/#laudos-ai/copiloto&Date)

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,16 +1,16 @@
 # electron-builder.yml
 
 # The unique application ID
-appId: com.pickle.glass
+appId: com.laudos.copiloto
 
 # The user-facing application name
-productName: Glass
+productName: "Copiloto - por Laudos.ai"
 
 # Publish configuration for GitHub releases
 publish:
     provider: github
     owner: pickle-com
-    repo: glass
+    repo: copiloto
     releaseType: draft
 
 # List of files to be included in the app package

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "functions": [
     {
       "source": "functions",
-      "codebase": "pickle-glass",
+      "codebase": "copiloto",
       "ignore": [
         "node_modules",
         ".git",

--- a/forge.config.js
+++ b/forge.config.js
@@ -8,13 +8,13 @@ module.exports = {
             unpack: '**/*.node,**/*.dylib,' + '**/node_modules/{sharp,@img}/**/*',
         },
         extraResource: ['./src/assets/SystemAudioDump', './pickleglass_web/out'],
-        name: 'Glass',
+        name: 'Copiloto - por Laudos.ai',
         icon: 'src/assets/logo',
-        appBundleId: 'com.pickle.glass',
+        appBundleId: 'com.laudos.copiloto',
         arch: 'universal',
         protocols: [
             {
-                name: 'PickleGlass Protocol',
+                name: 'Copiloto Protocol',
                 schemes: ['pickleglass'],
             },
         ],
@@ -44,9 +44,9 @@ module.exports = {
         {
             name: '@electron-forge/maker-squirrel',
             config: {
-                name: 'pickle-glass',
-                productName: 'Glass',
-                shortcutName: 'Glass',
+                name: 'copiloto',
+                productName: 'Copiloto - por Laudos.ai',
+                shortcutName: 'Copiloto',
                 createDesktopShortcut: true,
                 createStartMenuShortcut: true,
             },

--- a/functions/index.js
+++ b/functions/index.js
@@ -23,7 +23,7 @@ admin.initializeApp();
 // });
 
 /**
- * @name pickleGlassAuthCallback
+ * @name copilotoAuthCallback
  * @description
  * Validate Firebase ID token and return custom token.
  * On success, return success response with user information.
@@ -35,7 +35,7 @@ admin.initializeApp();
 const authCallbackHandler = (request, response) => {
   cors(request, response, async () => {
     try {
-      logger.info("pickleGlassAuthCallback function triggered", {
+      logger.info("copilotoAuthCallback function triggered", {
         body: request.body,
       });
 
@@ -83,7 +83,7 @@ const authCallbackHandler = (request, response) => {
   });
 };
 
-exports.pickleGlassAuthCallback = onRequest(
+exports.copilotoAuthCallback = onRequest(
     {region: "us-west1"},
     authCallbackHandler,
 );

--- a/package.json
+++ b/package.json
@@ -1,75 +1,75 @@
 {
-    "name": "pickle-glass",
-    "productName": "Glass",
-    "version": "0.1.2",
-    "description": "Cl*ely for Free",
-    "main": "src/index.js",
-    "scripts": {
-        "setup": "npm install && cd pickleglass_web && npm install && npm run build && cd .. && npm start",
-        "start": "npm run build:renderer && electron-forge start",
-        "package": "npm run build:renderer && electron-forge package",
-        "make": "npm run build:renderer && electron-forge make",
-        "build": "npm run build:renderer && electron-builder --config electron-builder.yml --publish never",
-        "publish": "npm run build:renderer && electron-builder --config electron-builder.yml --publish always",
-        "lint": "eslint --ext .ts,.tsx,.js .",
-        "postinstall": "electron-builder install-app-deps",
-        "build:renderer": "node build.js",
-        "watch:renderer": "node build.js --watch"
-    },
-    "keywords": [
-        "glass",
-        "pickle glass",
-        "ai assistant",
-        "real-time",
-        "live summary",
-        "contextual ai"
-    ],
-    "author": {
-        "name": "Pickle Team"
-    },
-    "license": "GPL-3.0",
-    "dependencies": {
-        "@google/genai": "^1.8.0",
-        "@google/generative-ai": "^0.24.1",
-        "axios": "^1.10.0",
-        "better-sqlite3": "^9.4.3",
-        "cors": "^2.8.5",
-        "dotenv": "^17.0.0",
-        "electron-deeplink": "^1.0.10",
-        "electron-squirrel-startup": "^1.0.1",
-        "electron-store": "^8.2.0",
-        "electron-updater": "^6.6.2",
-        "express": "^4.18.2",
-        "firebase": "^11.10.0",
-        "firebase-admin": "^13.4.0",
-        "jsonwebtoken": "^9.0.2",
-        "node-fetch": "^2.7.0",
-        "openai": "^4.70.0",
-        "react-hot-toast": "^2.5.2",
-        "sharp": "^0.34.2",
-        "sqlite3": "^5.1.7",
-        "validator": "^13.11.0",
-        "wait-on": "^8.0.3",
-        "ws": "^8.18.0"
-    },
-    "devDependencies": {
-        "@electron-forge/cli": "^7.8.1",
-        "@electron-forge/maker-deb": "^7.8.1",
-        "@electron-forge/maker-dmg": "^7.8.1",
-        "@electron-forge/maker-rpm": "^7.8.1",
-        "@electron-forge/maker-squirrel": "^7.8.1",
-        "@electron-forge/maker-zip": "^7.8.1",
-        "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
-        "@electron-forge/plugin-fuses": "^7.8.1",
-        "@electron/fuses": "^1.8.0",
-        "@electron/notarize": "^2.5.0",
-        "electron": "^30.5.1",
-        "electron-builder": "^26.0.12",
-        "electron-reloader": "^1.2.3",
-        "esbuild": "^0.25.5"
-    },
-    "optionalDependencies": {
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-libvips-darwin-x64": "^1.1.0"
-    }
+  "name": "copiloto",
+  "productName": "Copiloto - por Laudos.ai",
+  "version": "0.1.2",
+  "description": "Cl*ely for Free",
+  "main": "src/index.js",
+  "scripts": {
+    "setup": "npm install && cd pickleglass_web && npm install && npm run build && cd .. && npm start",
+    "start": "npm run build:renderer && electron-forge start",
+    "package": "npm run build:renderer && electron-forge package",
+    "make": "npm run build:renderer && electron-forge make",
+    "build": "npm run build:renderer && electron-builder --config electron-builder.yml --publish never",
+    "publish": "npm run build:renderer && electron-builder --config electron-builder.yml --publish always",
+    "lint": "eslint --ext .ts,.tsx,.js .",
+    "postinstall": "electron-builder install-app-deps",
+    "build:renderer": "node build.js",
+    "watch:renderer": "node build.js --watch"
+  },
+  "keywords": [
+    "copiloto - por laudos.ai",
+    "ai assistant",
+    "real-time",
+    "live summary",
+    "contextual ai"
+  ],
+  "author": {
+    "name": "Pickle Team"
+  },
+  "license": "GPL-3.0",
+  "dependencies": {
+    "@google/genai": "^1.8.0",
+    "@google/generative-ai": "^0.24.1",
+    "axios": "^1.10.0",
+    "better-sqlite3": "^9.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^17.0.0",
+    "electron-deeplink": "^1.0.10",
+    "electron-squirrel-startup": "^1.0.1",
+    "electron-store": "^8.2.0",
+    "electron-updater": "^6.6.2",
+    "express": "^4.18.2",
+    "firebase": "^11.10.0",
+    "firebase-admin": "^13.4.0",
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^2.7.0",
+    "openai": "^4.70.0",
+    "react-hot-toast": "^2.5.2",
+    "sharp": "^0.34.2",
+    "sqlite3": "^5.1.7",
+    "validator": "^13.11.0",
+    "wait-on": "^8.0.3",
+    "ws": "^8.18.0",
+    "robotjs": "^0.6.0"
+  },
+  "devDependencies": {
+    "@electron-forge/cli": "^7.8.1",
+    "@electron-forge/maker-deb": "^7.8.1",
+    "@electron-forge/maker-dmg": "^7.8.1",
+    "@electron-forge/maker-rpm": "^7.8.1",
+    "@electron-forge/maker-squirrel": "^7.8.1",
+    "@electron-forge/maker-zip": "^7.8.1",
+    "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
+    "@electron-forge/plugin-fuses": "^7.8.1",
+    "@electron/fuses": "^1.8.0",
+    "@electron/notarize": "^2.5.0",
+    "electron": "^30.5.1",
+    "electron-builder": "^26.0.12",
+    "electron-reloader": "^1.2.3",
+    "esbuild": "^0.25.5"
+  },
+  "optionalDependencies": {
+    "@img/sharp-darwin-x64": "^0.34.2",
+    "@img/sharp-libvips-darwin-x64": "^1.1.0"
+  }
 }

--- a/pickleglass_web/app/download/page.tsx
+++ b/pickleglass_web/app/download/page.tsx
@@ -20,9 +20,9 @@ export default function DownloadPage() {
   return (
     <div className="p-8">
       <div className="max-w-4xl mx-auto text-center">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">Download pickleglass</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Download Copiloto</h1>
         <p className="text-lg text-gray-600 mb-12">
-          Use pickleglass on various platforms
+          Use Copiloto on various platforms
         </p>
         
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">

--- a/pickleglass_web/app/help/page.tsx
+++ b/pickleglass_web/app/help/page.tsx
@@ -29,7 +29,7 @@ export default function HelpPage() {
               <h2 className="text-xl font-semibold text-gray-900">Getting Started</h2>
             </div>
             <p className="text-gray-600 mb-4">
-              New to pickleglass? Learn about basic features and setup methods.
+              New to copiloto? Learn about basic features and setup methods.
             </p>
             <ul className="space-y-2 text-sm text-gray-600">
               <li>• Setting up personalized contexts</li>

--- a/pickleglass_web/app/layout.tsx
+++ b/pickleglass_web/app/layout.tsx
@@ -5,7 +5,7 @@ import ClientLayout from '@/components/ClientLayout'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata = {
-  title: 'pickleglass - AI Assistant',
+  title: 'Copiloto - por Laudos.ai',
   description: 'Personalized AI Assistant for various contexts',
 }
 

--- a/pickleglass_web/app/login/page.tsx
+++ b/pickleglass_web/app/login/page.tsx
@@ -32,7 +32,7 @@ export default function LoginPage() {
           try {
             const idToken = await user.getIdToken()
             
-            const deepLinkUrl = `pickleglass://auth-success?` + new URLSearchParams({
+            const deepLinkUrl = `copiloto://auth-success?` + new URLSearchParams({
               uid: user.uid,
               email: user.email || '',
               displayName: user.displayName || '',
@@ -44,7 +44,7 @@ export default function LoginPage() {
             window.location.href = deepLinkUrl
             
             setTimeout(() => {
-              alert('Login completed. Please return to Pickle Glass app.')
+              alert('Login completed. Please return to Copiloto - por Laudos.ai app.')
             }, 1000)
             
           } catch (error) {
@@ -87,7 +87,7 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center">
       <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Welcome to Pickle Glass</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Welcome to Copiloto - por Laudos.ai</h1>
         <p className="text-gray-600 mt-2">Sign in with your Google account to sync your data across all devices.</p>
         {isElectronMode ? (
           <p className="text-sm text-blue-600 mt-1 font-medium">🔗 Login requested from Electron app</p>
@@ -111,7 +111,7 @@ export default function LoginPage() {
             <button
               onClick={() => {
                 if (isElectronMode) {
-                  window.location.href = 'pickleglass://auth-success?uid=default_user&email=contact@pickle.com&displayName=Default%20User'
+                  window.location.href = 'copiloto://auth-success?uid=default_user&email=contact@pickle.com&displayName=Default%20User'
                 } else {
                   router.push('/settings')
                 }

--- a/pickleglass_web/app/settings/page.tsx
+++ b/pickleglass_web/app/settings/page.tsx
@@ -202,7 +202,7 @@ export default function SettingsPage() {
           </div>
           
           <p className="text-gray-600 mb-6">
-            Experience how Pickle Glass works with unlimited responses.
+            Experience how Copiloto - por Laudos.ai works with unlimited responses.
           </p>
           
           <ul className="space-y-3 mb-8">
@@ -331,8 +331,8 @@ export default function SettingsPage() {
             <h4 className="font-semibold text-green-900">All features are currently free!</h4>
             <p className="text-green-700 text-sm">
               {isFirebaseMode 
-                ? 'Enjoy all Pickle Glass features for free in Firebase hosting mode. Pro and Enterprise plans will be released soon with additional premium features.'
-                : 'Enjoy all Pickle Glass features for free in local mode. You can use personal API keys or continue using the free system.'
+                ? 'Enjoy all Copiloto - por Laudos.ai features for free in Firebase hosting mode. Pro and Enterprise plans will be released soon with additional premium features.'
+                : 'Enjoy all Copiloto - por Laudos.ai features for free in local mode. You can use personal API keys or continue using the free system.'
               }
             </p>
           </div>
@@ -450,7 +450,7 @@ export default function SettingsPage() {
                  <p className="text-sm text-gray-600 mb-4">
                    {isFirebaseMode 
                      ? 'Permanently remove your Firebase account and all content. This action cannot be undone, so please proceed carefully.'
-                     : 'Permanently remove your personal account and all content from the Pickle Glass platform. This action cannot be undone, so please proceed carefully.'
+                     : 'Permanently remove your personal account and all content from the Copiloto - por Laudos.ai platform. This action cannot be undone, so please proceed carefully.'
                    }
                  </p>
                  <div className="mt-4 pt-4 border-t border-gray-200 flex justify-end">

--- a/pickleglass_web/components/Sidebar.tsx
+++ b/pickleglass_web/components/Sidebar.tsx
@@ -229,10 +229,10 @@ const SidebarComponent = ({ isCollapsed, onToggle, onSearchClick }: SidebarProps
                 ariaLabel: 'Download Pickle Camera (new window)',
             },
             {
-                href: 'hhttps://www.dropbox.com/scl/fi/znid09apxiwtwvxer6oc9/Glass_latest.dmg?rlkey=gwvvyb3bizkl25frhs4k1zwds&st=37q31b4w&dl=1',
+                href: 'hhttps://www.dropbox.com/scl/fi/znid09apxiwtwvxer6oc9/copiloto.dmg?rlkey=gwvvyb3bizkl25frhs4k1zwds&st=37q31b4w&dl=1',
                 icon: '/download.svg',
-                text: 'Download Pickle Glass',
-                ariaLabel: 'Download Pickle Glass (new window)',
+                text: 'Download Copiloto - por Laudos.ai',
+                ariaLabel: 'Download Copiloto - por Laudos.ai (new window)',
             },
         ],
         []

--- a/pickleglass_web/package.json
+++ b/pickleglass_web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pickleglass-frontend",
+  "name": "copiloto-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/pickleglass_web/utils/api.ts
+++ b/pickleglass_web/utils/api.ts
@@ -240,13 +240,13 @@ const userInfoListeners: Array<(userInfo: UserProfile | null) => void> = [];
 export const getUserInfo = (): UserProfile | null => {
   if (typeof window === 'undefined') return null;
   
-  const storedUserInfo = localStorage.getItem('pickleglass_user');
+  const storedUserInfo = localStorage.getItem('copiloto_user');
   if (storedUserInfo) {
     try {
       return JSON.parse(storedUserInfo);
     } catch (error) {
       console.error('Failed to parse user info:', error);
-      localStorage.removeItem('pickleglass_user');
+      localStorage.removeItem('copiloto_user');
     }
   }
   return null;
@@ -256,9 +256,9 @@ export const setUserInfo = (userInfo: UserProfile | null, skipEvents: boolean = 
   if (typeof window === 'undefined') return;
   
   if (userInfo) {
-    localStorage.setItem('pickleglass_user', JSON.stringify(userInfo));
+    localStorage.setItem('copiloto_user', JSON.stringify(userInfo));
   } else {
-    localStorage.removeItem('pickleglass_user');
+    localStorage.removeItem('copiloto_user');
   }
   
   if (!skipEvents) {

--- a/src/app/PermissionSetup.js
+++ b/src/app/PermissionSetup.js
@@ -521,7 +521,7 @@ export class PermissionSetup extends LitElement {
                             class="continue-button" 
                             @click=${this.handleContinue}
                         >
-                            Continue to Pickle Glass
+                            Continue to Copiloto - por Laudos.ai
                         </button>
                     ` : ''}
                 </div>

--- a/src/app/PickleGlassApp.js
+++ b/src/app/PickleGlassApp.js
@@ -6,7 +6,7 @@ import { AskView } from '../features/ask/AskView.js';
 
 import '../features/listen/renderer.js';
 
-export class PickleGlassApp extends LitElement {
+export class CopilotoApp extends LitElement {
     static styles = css`
         :host {
             display: block;
@@ -68,7 +68,7 @@ export class PickleGlassApp extends LitElement {
         this.outlines = [];
         this.analysisRequests = [];
 
-        window.pickleGlass.setStructuredData = data => {
+        window.copiloto.setStructuredData = data => {
             this.updateStructuredData(data);
         };
     }
@@ -165,9 +165,9 @@ export class PickleGlassApp extends LitElement {
             }
         }
 
-        if (window.pickleGlass) {
-            await window.pickleGlass.initializeopenai(this.selectedProfile, this.selectedLanguage);
-            window.pickleGlass.startCapture(this.selectedScreenshotInterval, this.selectedImageQuality);
+        if (window.copiloto) {
+            await window.copiloto.initializeopenai(this.selectedProfile, this.selectedLanguage);
+            window.copiloto.startCapture(this.selectedScreenshotInterval, this.selectedImageQuality);
         }
 
         // 🔄 Clear previous summary/analysis when a new listening session begins
@@ -215,8 +215,8 @@ export class PickleGlassApp extends LitElement {
     }
 
     async handleSendText(message) {
-        if (window.pickleGlass) {
-            const result = await window.pickleGlass.sendTextMessage(message);
+        if (window.copiloto) {
+            const result = await window.copiloto.sendTextMessage(message);
 
             if (!result.success) {
                 console.error('Failed to send message:', result.error);
@@ -228,19 +228,19 @@ export class PickleGlassApp extends LitElement {
     }
 
     // updateOutline(outline) {
-    //     console.log('📝 PickleGlassApp updateOutline:', outline);
+    //     console.log('📝 CopilotoApp updateOutline:', outline);
     //     this.outlines = [...outline];
     //     this.requestUpdate();
     // }
 
     // updateAnalysisRequests(requests) {
-    //     console.log('📝 PickleGlassApp updateAnalysisRequests:', requests);
+    //     console.log('📝 CopilotoApp updateAnalysisRequests:', requests);
     //     this.analysisRequests = [...requests];
     //     this.requestUpdate();
     // }
 
     updateStructuredData(data) {
-        console.log('📝 PickleGlassApp updateStructuredData:', data);
+        console.log('📝 CopilotoApp updateStructuredData:', data);
         this.structuredData = data;
         this.requestUpdate();
         
@@ -292,4 +292,4 @@ export class PickleGlassApp extends LitElement {
     }
 }
 
-customElements.define('pickle-glass-app', PickleGlassApp);
+customElements.define('copiloto-app', CopilotoApp);

--- a/src/app/content.html
+++ b/src/app/content.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta http-equiv="content-security-policy" content="script-src 'self' 'unsafe-inline'" />
-        <title>Pickle Glass Content</title>
+        <title>Copiloto - por Laudos.ai Content</title>
         <style>
             :root {
                 --background-transparent: transparent;
@@ -88,7 +88,7 @@
                 box-sizing: border-box;
             }
 
-            pickle-glass-app {
+            copiloto-app {
                 display: block;
                 width: 100%;
                 transform: translate3d(0, 0, 0);
@@ -232,7 +232,7 @@
         
         <script type="module" src="../../public/build/content.js"></script>
 
-        <pickle-glass-app id="pickle-glass"></pickle-glass-app>
+        <copiloto-app id="pickle-glass"></copiloto-app>
         
         <script>
             window.addEventListener('DOMContentLoaded', () => {

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta http-equiv="content-security-policy" content="script-src 'self' 'unsafe-inline'" />
-        <title>Pickle Glass Header</title>
+        <title>Copiloto - por Laudos.ai Header</title>
         <style>
             html,
             body {

--- a/src/common/config/config.js
+++ b/src/common/config/config.js
@@ -7,10 +7,10 @@ class Config {
     constructor() {
         this.env = process.env.NODE_ENV || 'development';
         this.defaults = {
-            apiUrl: process.env.pickleglass_API_URL || 'http://localhost:9001',
+            apiUrl: process.env.copiloto_API_URL || 'http://localhost:9001',
             apiTimeout: 10000,
             
-            webUrl: process.env.pickleglass_WEB_URL || 'http://localhost:3000',
+            webUrl: process.env.copiloto_WEB_URL || 'http://localhost:3000',
             
             enableJWT: false,
             fallbackToHeaderAuth: false,
@@ -38,34 +38,34 @@ class Config {
     }
     
     loadEnvironmentConfig() {
-        if (process.env.pickleglass_API_URL) {
-            this.config.apiUrl = process.env.pickleglass_API_URL;
+        if (process.env.copiloto_API_URL) {
+            this.config.apiUrl = process.env.copiloto_API_URL;
             console.log(`[Config] API URL from env: ${this.config.apiUrl}`);
         }
         
-        if (process.env.pickleglass_WEB_URL) {
-            this.config.webUrl = process.env.pickleglass_WEB_URL;
+        if (process.env.copiloto_WEB_URL) {
+            this.config.webUrl = process.env.copiloto_WEB_URL;
             console.log(`[Config] Web URL from env: ${this.config.webUrl}`);
         }
         
-        if (process.env.pickleglass_API_TIMEOUT) {
-            this.config.apiTimeout = parseInt(process.env.pickleglass_API_TIMEOUT);
+        if (process.env.copiloto_API_TIMEOUT) {
+            this.config.apiTimeout = parseInt(process.env.copiloto_API_TIMEOUT);
         }
         
-        if (process.env.pickleglass_ENABLE_JWT) {
-            this.config.enableJWT = process.env.pickleglass_ENABLE_JWT === 'true';
+        if (process.env.copiloto_ENABLE_JWT) {
+            this.config.enableJWT = process.env.copiloto_ENABLE_JWT === 'true';
         }
         
-        if (process.env.pickleglass_CACHE_TIMEOUT) {
-            this.config.cacheTimeout = parseInt(process.env.pickleglass_CACHE_TIMEOUT);
+        if (process.env.copiloto_CACHE_TIMEOUT) {
+            this.config.cacheTimeout = parseInt(process.env.copiloto_CACHE_TIMEOUT);
         }
         
-        if (process.env.pickleglass_LOG_LEVEL) {
-            this.config.logLevel = process.env.pickleglass_LOG_LEVEL;
+        if (process.env.copiloto_LOG_LEVEL) {
+            this.config.logLevel = process.env.copiloto_LOG_LEVEL;
         }
         
-        if (process.env.pickleglass_DEBUG) {
-            this.config.enableDebugLogging = process.env.pickleglass_DEBUG === 'true';
+        if (process.env.copiloto_DEBUG) {
+            this.config.enableDebugLogging = process.env.copiloto_DEBUG === 'true';
         }
         
         if (this.env === 'production') {

--- a/src/electron/windowManager.js
+++ b/src/electron/windowManager.js
@@ -920,12 +920,12 @@ function toggleAllWindowsVisibility() {
 
 function ensureDataDirectories() {
     const homeDir = os.homedir();
-    const pickleGlassDir = path.join(homeDir, '.pickle-glass');
-    const dataDir = path.join(pickleGlassDir, 'data');
+    const copilotoDir = path.join(homeDir, '.pickle-glass');
+    const dataDir = path.join(copilotoDir, 'data');
     const imageDir = path.join(dataDir, 'image');
     const audioDir = path.join(dataDir, 'audio');
 
-    [pickleGlassDir, dataDir, imageDir, audioDir].forEach(dir => {
+    [copilotoDir, dataDir, imageDir, audioDir].forEach(dir => {
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }
@@ -1046,17 +1046,17 @@ function createWindows() {
                     const hasResponse = await askWindow.webContents.executeJavaScript(`
                         (() => {
                             try {
-                                // PickleGlassApp의 Shadow DOM 내부로 접근
-                                const pickleApp = document.querySelector('pickle-glass-app');
+                                // CopilotoApp의 Shadow DOM 내부로 접근
+                                const pickleApp = document.querySelector('copiloto-app');
                                 if (!pickleApp || !pickleApp.shadowRoot) {
-                                    console.log('PickleGlassApp not found');
+                                    console.log('CopilotoApp not found');
                                     return false;
                                 }
                                 
-                                // PickleGlassApp의 shadowRoot 내부에서 ask-view 찾기
+                                // CopilotoApp의 shadowRoot 내부에서 ask-view 찾기
                                 const askView = pickleApp.shadowRoot.querySelector('ask-view');
                                 if (!askView) {
-                                    console.log('AskView not found in PickleGlassApp shadow DOM');
+                                    console.log('AskView not found in CopilotoApp shadow DOM');
                                     return false;
                                 }
                                 

--- a/src/features/ask/AskView.js
+++ b/src/features/ask/AskView.js
@@ -1125,7 +1125,7 @@ export class AskView extends LitElement {
         this.requestUpdate();
         this.renderContent();
 
-        window.pickleGlass.sendMessage(question).catch(error => {
+        window.copiloto.sendMessage(question).catch(error => {
             console.error('Error processing assistant question:', error);
             this.isLoading = false;
             this.isStreaming = false;
@@ -1221,7 +1221,7 @@ export class AskView extends LitElement {
         this.requestUpdate();
         this.renderContent();
 
-        window.pickleGlass.sendMessage(text).catch(error => {
+        window.copiloto.sendMessage(text).catch(error => {
             console.error('Error sending text:', error);
             this.isLoading = false;
             this.isStreaming = false;

--- a/src/features/customize/CustomizeView.js
+++ b/src/features/customize/CustomizeView.js
@@ -552,7 +552,7 @@ export class CustomizeView extends LitElement {
     }
 
     getDefaultKeybinds() {
-        const isMac = window.pickleGlass?.isMacOS || navigator.platform.includes('Mac');
+        const isMac = window.copiloto?.isMacOS || navigator.platform.includes('Mac');
         return {
             moveUp: isMac ? 'Cmd+Up' : 'Ctrl+Up',
             moveDown: isMac ? 'Cmd+Down' : 'Ctrl+Down',
@@ -896,7 +896,7 @@ export class CustomizeView extends LitElement {
             <div class="settings-container">
                 <div class="header-section">
                     <div>
-                        <h1 class="app-title">Pickle Glass</h1>
+                        <h1 class="app-title">Copiloto - por Laudos.ai</h1>
                         <div class="account-info">
                             ${this.firebaseUser
                                 ? html`Account: ${this.firebaseUser.email || 'Logged In'}`

--- a/src/features/listen/AssistantView.js
+++ b/src/features/listen/AssistantView.js
@@ -1075,10 +1075,10 @@ export class AssistantView extends LitElement {
         const displayText = this.isHovering
             ? this.viewMode === 'transcript'
                 ? 'Copy Transcript'
-                : 'Copy Glass Analysis'
+                : 'Copiar Análise'
             : this.viewMode === 'insights'
             ? `Live insights`
-            : `Glass is Listening ${this.elapsedTime}`;
+            : `Copiloto ouvindo ${this.elapsedTime}`;
 
         const data = this.structuredData || {
             summary: [],

--- a/src/features/listen/renderer.js
+++ b/src/features/listen/renderer.js
@@ -37,7 +37,7 @@ let lastScreenshotBase64 = null; // Store the latest screenshot
 let realtimeConversationHistory = [];
 
 const PICKLE_GLASS_SYSTEM_PROMPT = `<core_identity>
-You are Pickle-Glass, developed and created by Pickle-Glass, and you are the user's live-meeting co-pilot.
+You are Copiloto, developed by Laudos.ai, and you are the user's live-meeting co-pilot.
 </core_identity>
 
 <objective>
@@ -345,7 +345,7 @@ let aecProcessor = new SimpleAEC();
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
 
-window.pickleGlass = window.pickleGlass || {};
+window.copiloto = window.copiloto || {};
 
 let tokenTracker = {
     tokens: [],
@@ -428,7 +428,7 @@ setInterval(() => {
     tokenTracker.trackAudioTokens();
 }, 2000);
 
-function pickleGlassElement() {
+function copilotoElement() {
     return document.getElementById('pickle-glass');
 }
 
@@ -463,14 +463,14 @@ async function initializeopenai(profile = 'interview', language = 'en') {
             console.log('OpenAI initialization successful.');
         } else {
             console.error('OpenAI initialization failed.');
-            const appElement = pickleGlassElement();
+            const appElement = copilotoElement();
             if (appElement && typeof appElement.setStatus === 'function') {
                 appElement.setStatus('Initialization Failed');
             }
         }
     } catch (error) {
         console.error('Error during OpenAI initialization IPC call:', error);
-        const appElement = pickleGlassElement();
+        const appElement = copilotoElement();
         if (appElement && typeof appElement.setStatus === 'function') {
             appElement.setStatus('Error');
         }
@@ -495,7 +495,7 @@ ipcRenderer.on('system-audio-data', (event, { data }) => {
 // Listen for status updates
 ipcRenderer.on('update-status', (event, status) => {
     console.log('Status update:', status);
-    pickleGlass.e().setStatus(status);
+    copiloto.e().setStatus(status);
 });
 
 // Listen for real-time STT updates
@@ -521,8 +521,8 @@ ipcRenderer.on('stt-update', (event, data) => {
         console.log(`📋 Latest text: ${conversationText}`);
     }
 
-    if (pickleGlass.e() && typeof pickleGlass.e().updateRealtimeTranscription === 'function') {
-        pickleGlass.e().updateRealtimeTranscription({
+    if (copiloto.e() && typeof copiloto.e().updateRealtimeTranscription === 'function') {
+        copiloto.e().updateRealtimeTranscription({
             speaker,
             text,
             isFinal,
@@ -535,17 +535,17 @@ ipcRenderer.on('stt-update', (event, data) => {
 
 ipcRenderer.on('update-structured-data', (_, structuredData) => {
     console.log('📥 Received structured data update:', structuredData);
-    window.pickleGlass.structuredData = structuredData;
-    window.pickleGlass.setStructuredData(structuredData);
+    window.copiloto.structuredData = structuredData;
+    window.copiloto.setStructuredData(structuredData);
 });
-window.pickleGlass.structuredData = {
+window.copiloto.structuredData = {
     summary: [],
     topic: { header: '', bullets: [] },
     actions: [],
 };
-window.pickleGlass.setStructuredData = data => {
-    window.pickleGlass.structuredData = data;
-    pickleGlass.e()?.updateStructuredData?.(data);
+window.copiloto.setStructuredData = data => {
+    window.copiloto.structuredData = data;
+    copiloto.e()?.updateStructuredData?.(data);
 };
 
 async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'medium') {
@@ -674,7 +674,7 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
         }
     } catch (err) {
         console.error('Error starting capture:', err);
-        pickleGlass.e().setStatus('error');
+        copiloto.e().setStatus('error');
     }
 }
 
@@ -1122,7 +1122,7 @@ async function getAllConversationSessions() {
 // Initialize conversation storage when renderer loads
 initConversationStorage().catch(console.error);
 
-window.pickleGlass = {
+window.copiloto = {
     initializeopenai,
     startCapture,
     stopCapture,
@@ -1133,7 +1133,7 @@ window.pickleGlass = {
     initConversationStorage,
     isLinux: isLinux,
     isMacOS: isMacOS,
-    e: pickleGlassElement,
+    e: copilotoElement,
 };
 
 // -------------------------------------------------------
@@ -1157,6 +1157,6 @@ ipcRenderer.on('session-state-changed', (_event, { isActive }) => {
             actions: [],
             followUps: [],
         };
-        window.pickleGlass.setStructuredData(blankData);
+        window.copiloto.setStructuredData(blankData);
     }
 });

--- a/src/features/onboarding/OnboardingView.js
+++ b/src/features/onboarding/OnboardingView.js
@@ -248,9 +248,9 @@ export class OnboardingView extends LitElement {
         return html`
             <div class="slide slide-1 ${this.currentSlide === 0 ? 'active' : ''}">
                 <div class="emoji">👋</div>
-                <div class="slide-title">Welcome to Pickle Glass!</div>
+                <div class="slide-title">Welcome to Copiloto - por Laudos.ai!</div>
                 <div class="slide-content">
-                    Pickle Glass hears what you hear and sees what you see, then generates AI-powered suggestions without any user input needed.
+                    Copiloto - por Laudos.ai hears what you hear and sees what you see, then generates AI-powered suggestions without any user input needed.
                 </div>
             </div>
         `;
@@ -317,7 +317,7 @@ export class OnboardingView extends LitElement {
                 <div class="emoji">🎉</div>
                 <div class="slide-title">You're All Set!</div>
                 <div class="slide-content">
-                    Pickle Glass is completely free to use. Just add your openai API key and start getting AI-powered assistance in your interviews
+                    Copiloto - por Laudos.ai is completely free to use. Just add your openai API key and start getting AI-powered assistance in your interviews
                     and meetings!
                 </div>
             </div>

--- a/src/features/radiology/reportGenerator.js
+++ b/src/features/radiology/reportGenerator.js
@@ -1,0 +1,29 @@
+const { createOpenAiGenerativeClient, getOpenAiGenerativeModel } = require('../../common/services/openAiClient');
+const { clipboard } = require('electron');
+let robot;
+try {
+  robot = require('robotjs');
+} catch (e) {
+  console.warn('robotjs not installed');
+}
+
+const RADIOLOGY_SYSTEM_PROMPT = process.env.radiology_system_prompt ||
+  'Você é um radiologista especializado em gerar laudos claros e completos. Utilize o seguinte histórico para compor o laudo:';
+
+async function generateRadiologyReport(transcript, apiKey) {
+  const client = createOpenAiGenerativeClient(apiKey);
+  const model = getOpenAiGenerativeModel(client, 'gpt-4o');
+  const result = await model.generateContent([RADIOLOGY_SYSTEM_PROMPT, transcript]);
+  const report = await result.response.text();
+  return report;
+}
+
+function pasteText(text) {
+  clipboard.writeText(text);
+  if (robot) {
+    const isMac = process.platform === 'darwin';
+    robot.keyTap('v', isMac ? 'command' : 'control');
+  }
+}
+
+module.exports = { generateRadiologyReport, pasteText };

--- a/src/index.js
+++ b/src/index.js
@@ -214,15 +214,15 @@ function setupGeneralIpcHandlers() {
     });
 
     ipcMain.handle('get-api-url', () => {
-        return process.env.pickleglass_API_URL || 'http://localhost:9001';
+        return process.env.copiloto_API_URL || 'http://localhost:9001';
     });
 
     ipcMain.handle('get-web-url', () => {
-        return process.env.pickleglass_WEB_URL || 'http://localhost:3000';
+        return process.env.copiloto_WEB_URL || 'http://localhost:3000';
     });
 
     ipcMain.on('get-api-url-sync', (event) => {
-        event.returnValue = process.env.pickleglass_API_URL || 'http://localhost:9001';
+        event.returnValue = process.env.copiloto_API_URL || 'http://localhost:9001';
     });
 
     ipcMain.handle('get-database-status', async () => {
@@ -254,6 +254,17 @@ function setupGeneralIpcHandlers() {
         }
     });
 
+    ipcMain.handle("generate-radiology-report", async (_e, { transcript, apiKey }) => {
+        const { generateRadiologyReport, pasteText } = require("./features/radiology/reportGenerator");
+        try {
+            const report = await generateRadiologyReport(transcript, apiKey);
+            pasteText(report);
+            return { success: true, report };
+        } catch (error) {
+            console.error("Failed to generate radiology report:", error);
+            return { success: false, error: error.message };
+        }
+    });
 }
 
 async function handleCustomUrl(url) {
@@ -311,7 +322,7 @@ async function handleFirebaseAuthCallback(params) {
     console.log('[Auth] Received ID token from deep link, exchanging for custom token...');
 
     try {
-        const functionUrl = 'https://us-west1-pickle-3651a.cloudfunctions.net/pickleGlassAuthCallback';
+        const functionUrl = 'https://us-west1-pickle-3651a.cloudfunctions.net/copilotoAuthCallback';
         const response = await fetch(functionUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -451,14 +462,14 @@ async function startWebStack() {
 
   console.log(`🔧 Allocated ports: API=${apiPort}, Frontend=${frontendPort}`);
 
-  process.env.pickleglass_API_PORT = apiPort.toString();
-  process.env.pickleglass_API_URL = `http://localhost:${apiPort}`;
-  process.env.pickleglass_WEB_PORT = frontendPort.toString();
-  process.env.pickleglass_WEB_URL = `http://localhost:${frontendPort}`;
+  process.env.copiloto_API_PORT = apiPort.toString();
+  process.env.copiloto_API_URL = `http://localhost:${apiPort}`;
+  process.env.copiloto_WEB_PORT = frontendPort.toString();
+  process.env.copiloto_WEB_URL = `http://localhost:${frontendPort}`;
 
   console.log(`🌍 Environment variables set:`, {
-    pickleglass_API_URL: process.env.pickleglass_API_URL,
-    pickleglass_WEB_URL: process.env.pickleglass_WEB_URL
+    copiloto_API_URL: process.env.copiloto_API_URL,
+    copiloto_WEB_URL: process.env.copiloto_WEB_URL
   });
 
   const createBackendApp = require('../pickleglass_web/backend_node');
@@ -581,7 +592,7 @@ function initAutoUpdater() {
                 type: 'info',
                 buttons: ['Install now', 'Install on next launch'],
                 title: 'Update Available',
-                message: 'A new version of Glass is ready to be installed.',
+                message: 'Uma nova versão do Copiloto está pronta para ser instalada.',
                 defaultId: 0,
                 cancelId: 1
             };


### PR DESCRIPTION
## Summary
- rename brand to **Copiloto** and translate initial documentation to pt-BR
- replace user-facing references to Glass
- add radiology report generator using `radiology_system_prompt`
- auto paste generated report into the current cursor location
- update configuration and package metadata

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6869cdf37ca083299e3dfb3b7fe3a97b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to generate radiology reports using AI and automatically paste the results.

* **Bug Fixes**
  * Updated all user-facing text, branding, and URLs from "Pickle Glass" to "Copiloto - por Laudos.ai."
  * Translated user interface elements and documentation to Portuguese.
  * Updated download links, deep link schemes, and protocol names to match new branding.
  * Changed environment variable prefixes and storage keys to reflect the new product name.

* **Chores**
  * Updated documentation and configuration files to reflect the rebranding.
  * Added a new dependency to support keyboard automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->